### PR TITLE
Use snyk/snyk-cli docker images to compute dependency graph

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,17 +23,19 @@ The Datadog Github Action continuously monitors dependency and version informati
 1. Start by setting up or adding onto an existing [Github Actions Workflow](https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-syntax-for-github-actions).
 2. Next, identify the Datadog Profiling Services in Datadog where you want to set up Vulnerability Security tracking. You'll need the service name that is in the Service column of your [Datadog Profiling page](https://app.datadoghq.com/profiling).
    <img width="1205" alt="Service name" src="https://user-images.githubusercontent.com/28788585/101665423-30ef3880-3a0a-11eb-9740-2ab71d20e22a.png">
-3. Depending on your language and build system, find the matching Snyk Github Action in the following table:
+3. Depending on your language and build system, find the matching Snyk CLI Docker Image in the following table:
 
-| Name              | Snyk Github Action Repository        |
-| ----------------- | ------------------------------------ |
-| Gradle            | `snyk/actions/gradle@master`         |
-| Gradle-jdk11      | `snyk/actions/gradle-jdk11@master`   |
-| Gradle-jdk12      | `snyk/actions/gradle-jdk12@master`   |
-| Maven             | `snyk/actions/maven@master`          |
-| Maven-3-jdk-11    | `snyk/actions/maven-3-jdk-11@master` |
+| Name                     | Snyk CLI Docker Image                |
+| ------------------------ | ------------------------------------ |
+| Gradle 5.4               | `snyk/snyk-cli:gradle-5.4`           |
+| Gradle 5.4 with Java 11  | `snyk/snyk-cli:gradle-5.4_java11`    |
+| Gradle 4.4               | `snyk/snyk-cli:gradle-4.4`           |
+| Gradle 2.8               | `snyk/snyk-cli:gradle-2.8`           |
+| Maven 3.6.3              | `snyk/snyk-cli:maven-3.6.3`          |
+| Maven 3.6.3 with Java 11 | `snyk/snyk-cli:maven-3.6.3_java11`   |
+| Maven 3.5.4              | `snyk/snyk-cli:maven-3.5.4`          |
 
-4. Define the service and the version that should be monitored and connect Datadog and Snyk to your Github Actions workflow by editing your Github Actions workflow YAML file to include the parameters `Snyk Github Action repository`, `build file`, `service`, `version`, `site`, `DATADOG_API_KEY`, `DATADOG_APP_KEY`, and `SNYK_TOKEN`. For a full list of fields, see [Inputs](#inputs). Here is an example yaml:
+4. Define the service and the version that should be monitored and connect Datadog and Snyk to your Github Actions workflow by editing your Github Actions workflow YAML file to include the parameters `Snyk CLI Docker Image`, `build file`, `service`, `version`, `site`, `DATADOG_API_KEY`, `DATADOG_APP_KEY`, and `SNYK_TOKEN`. For a full list of fields, see [Inputs](#inputs). Here is an example yaml:
 
 
 ```yaml
@@ -48,11 +50,8 @@ jobs:
         with:
           node-version: 12.x
       - name: Compute dependency graph
-        uses: <Snyk Github Action repository>
+        run: docker run -e "SNYK_TOKEN=$SNYK_TOKEN" -v "$PWD:/project" <Snyk CLI Docker Image> test --print-deps --json --file=<build file> > deps.json
         continue-on-error: true
-        with:
-          args: --print-deps --json --file=<build file>
-          json: true
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
       - name: Upload dependency graph to Datadog
@@ -85,11 +84,8 @@ jobs:
         with:
           node-version: 12.x
       - name: Compute dependency graph
-        uses: snyk/actions/gradle@master
+        run: docker run -e "SNYK_TOKEN=$SNYK_TOKEN" -v "$PWD:/project" snyk/snyk-cli:gradle-5.4 test --print-deps --json --file=<build file> > deps.json
         continue-on-error: true
-        with:
-          args: --print-deps --json --file=app/build.gradle # Do not add quotes
-          json: true
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
       - name: Upload dependency graph to Datadog
@@ -121,7 +117,7 @@ The Search view can be used to gather insights on how often specific vulnerabili
 
 | Name              | Requirement | Default | Description |
 | ----------------- | ----------- | ------- | ----------- |
-| `Snyk Github Action Repository`| _required | | The path to the Snyk Github Action that computes the dependency graph. Example: `snyk/actions/gradle@master` |
+| `Snyk CLI Docker Image`| _required | | The path to the Snyk CLI Docker Image that computes the dependency graph. Example: `snyk/snyk-cli:gradle-5.4` |
 | `build file`      | _required_  |         | The build file of the service. Example: `app/build.gradle` or `app/build.gradle.kts`|
 | `service`         | _required_  |         | The service name. Example: `app-name`|
 | `version`         | _required_  |         | The version of the application. Example: `v2.1`|

--- a/action.yml
+++ b/action.yml
@@ -26,15 +26,19 @@ runs:
   - name: Install Datadog-ci
     run: npm install -g --save-dev @datadog/datadog-ci
     shell: bash
-  # TODO: Analyse snyk.json file to check the content is valid and report errors to the user
+  # TODO: Analyse deps.json file to check the content is valid and report errors to the user
   - name: Compress dependency graph
     run: |
-      echo "Compacting dep graph"
-      cat snyk.json | jq -c '.' > snyk_tmp.json
-      mv snyk_tmp.json snyk.json
+      echo "Show 10 first lines of deps.json"
+      head -n10 deps.json
+      echo "Compacting the dependency graph"
+      cat deps.json | grep -v "Failed to run the process" | jq -c '.' > snyk_tmp.json
+      echo "Removing content other than the dependency graph (i.e the vulnerability analysis)"
+      head -n1 snyk_tmp.json > deps.json
+      echo "Size of deps.json: `du -sh deps.json | cut -d' ' -f2`"
     shell: bash
   - name: Upload dependency graph
-    run: datadog-ci dependencies upload ./snyk.json --source snyk --service ${{ inputs.service }} --release-version ${{ inputs.version }}
+    run: datadog-ci dependencies upload ./deps.json --source snyk --service ${{ inputs.service }} --release-version ${{ inputs.version }}
     shell: bash
     env:
       DATADOG_SITE: ${{ inputs.site }}


### PR DESCRIPTION
This PR replaces current Snyk Github actions (https://github.com/snyk/actions) used to compute the dependency graph with Snyk CLI Docker images.

Snyk Github actions were not working because these actions use internally the `--json-file-output` option to dump the `snyk test` output in JSON format. The drawback is that when computing the dependency graph, the graph output is not included and the json file only includes the vulnerability analysis. A misleading side-effect is that the output on stdout was showing the dependency graph computation but the stderr output is different from the JSON file output.

Due to Github action syntax and limitations, it is not possible to dump stdout using a bash redirection (`... > deps.json`) so I switched to Snyk CLI docker images.

This PR also adds some debugging logs, shows the `deps.json` file size and the 10 first lines of `deps.json`. The vulnerability analysis is also removed from the file and not uploaded to Datadog to remain under the file size upload limit.


