### PR TITLE
Allow depgraph computation to fail

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,15 +51,13 @@ jobs:
           node-version: 12.x
       - name: Compute dependency graph
         run: docker run -e "SNYK_TOKEN=$SNYK_TOKEN" -v "$PWD:/project" <Snyk CLI Docker Image> test --print-deps --file=<build file>
+        continue-on-error: true
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
       - name:  Display dependency graph computation errors
-        if: ${{ failure() }}
         run: |
           echo "-- Display snyk-error.log file"
           cat snyk-error.log
-          echo "-- Display snyk-result.log file"
-          cat snyk-result.log
       - name: Upload dependency graph to Datadog
         uses: datadog/github-action-vulnerability-analysis@v0.3.2
         with:


### PR DESCRIPTION
The Snyk docker image sometimes returns a non-0 exit code even when the graph is computed.

This PR allows the graph computation step to fail so that the action can proceed to next steps.